### PR TITLE
feature/ID82 sample validation

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -42,25 +42,24 @@ static tMotorControl_State MotorControl_State;
  * @note This function is typically called from an ADC ISR context.
  */
 void vMotorControl_OnAdcSample(int16_t i16BusRaw) {
-    /* 1. Sensing */
-    vCurrentSensing_UpdateRaw(i16BusRaw);
+  /* 1. Sensing */
+  vCurrentSensing_UpdateRaw(i16BusRaw);
 
-    /* 2. (Opcional) validar muestra */
-    if (!vCurrentSensing_IsReady())
-        return;
+  /* 2. (Opcional) validar muestra */
+  if (!vCurrentSensing_IsReady())
+    return;
 
-    /* 3. Contar muestra */
-    MotorControl_State.ui8SampleCount++;
+  /* 3. Contar muestra */
+  MotorControl_State.ui8SampleCount++;
 
-    /* 4. Gating configurable */
-    if (MotorControl_State.ui8SampleCount >=
-        MotorControl_State.ui8SamplesPerPwm)
-    {
-        MotorControl_State.ui8SampleCount = 0;
+  /* 4. Gating configurable */
+  if (MotorControl_State.ui8SampleCount >=
+      MotorControl_State.ui8SamplesPerPwm) {
+    MotorControl_State.ui8SampleCount = 0;
 
-        /* listo para ejecutar control */
-        vMotorControl_SetSampleReady(true);
-    }
+    /* listo para ejecutar control */
+    vMotorControl_SetSampleReady(true);
+  }
 }
 
 /**

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -42,14 +42,25 @@ static tMotorControl_State MotorControl_State;
  * @note This function is typically called from an ADC ISR context.
  */
 void vMotorControl_OnAdcSample(int16_t i16BusRaw) {
-  /* 1. Forward raw data to sensing layer */
-  vCurrentSensing_UpdateRaw(i16BusRaw);
+    /* 1. Sensing */
+    vCurrentSensing_UpdateRaw(i16BusRaw);
 
-  /* 2. Mark sample as available */
-  vMotorControl_SetSampleReady(true);
+    /* 2. (Opcional) validar muestra */
+    if (!vCurrentSensing_IsReady())
+        return;
 
-  /* 3. Update sampling counter (per PWM cycle) */
-  MotorControl_State.ui8SampleCount++;
+    /* 3. Contar muestra */
+    MotorControl_State.ui8SampleCount++;
+
+    /* 4. Gating configurable */
+    if (MotorControl_State.ui8SampleCount >=
+        MotorControl_State.ui8SamplesPerPwm)
+    {
+        MotorControl_State.ui8SampleCount = 0;
+
+        /* listo para ejecutar control */
+        vMotorControl_SetSampleReady(true);
+    }
 }
 
 /**

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -184,7 +184,8 @@ void vKernelInterface_ADCIRQHandler(void) {
     vMotorControl_OnAdcSample(i16VoltageBus);
 
     /* 3. Check if enough samples are available (typically 2 per PWM cycle) */
-
+    /*this step is inside vMotorControl_OnAdcSample function*/
+    
     /* 4. Detect active SVPWM sector (1..6) */
 
     /* 5. Reconstruct phase currents from DC-link current */

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -185,7 +185,7 @@ void vKernelInterface_ADCIRQHandler(void) {
 
     /* 3. Check if enough samples are available (typically 2 per PWM cycle) */
     /*this step is inside vMotorControl_OnAdcSample function*/
-    
+
     /* 4. Detect active SVPWM sector (1..6) */
 
     /* 5. Reconstruct phase currents from DC-link current */

--- a/STM32CubeIDE/src_STM32Kernel/KernelInterface.h
+++ b/STM32CubeIDE/src_STM32Kernel/KernelInterface.h
@@ -28,10 +28,10 @@
  *
  * @note Must be called before enabling any interrupts that rely on GPIOs.
  */
+#include "adc.h"
 #include "spwm.h"
 #include "svm.h"
 #include "uart.h"
-#include "adc.h"
 #include <stdint.h>
 #include <tim.h>
 

--- a/STM32CubeIDE/src_STM32Kernel/KernelInterface.h
+++ b/STM32CubeIDE/src_STM32Kernel/KernelInterface.h
@@ -31,6 +31,7 @@
 #include "spwm.h"
 #include "svm.h"
 #include "uart.h"
+#include "adc.h"
 #include <stdint.h>
 #include <tim.h>
 

--- a/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
+++ b/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
@@ -54,7 +54,6 @@ void vCurrentSensing_UpdateRaw(int16_t i16AdcRaw) {
   CurrentSensing_State.ui8Valid = 1;
 }
 
-bool vCurrentSensing_IsReady(void)
-{
-    return (CurrentSensing_State.ui8Valid != 0);
+bool vCurrentSensing_IsReady(void) {
+  return (CurrentSensing_State.ui8Valid != 0);
 }

--- a/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
+++ b/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
@@ -53,3 +53,8 @@ void vCurrentSensing_UpdateRaw(int16_t i16AdcRaw) {
   /* Mark sample as valid */
   CurrentSensing_State.ui8Valid = 1;
 }
+
+bool vCurrentSensing_IsReady(void)
+{
+    return (CurrentSensing_State.ui8Valid != 0);
+}


### PR DESCRIPTION
This PR implements step 3 of the control pipeline, introducing a flexible mechanism to determine when enough ADC samples are available to trigger the control loop.

The design supports both:

single-sample execution (FOC per sample)
multi-sample strategies (e.g., single-shunt reconstruction)

Key changes

- Added sample counting mechanism:
- ui8SampleCount
- ui8SamplesPerPwm
- Implemented configurable sample gating logic
- Control loop is triggered only when required number of samples is reached

CurrentSensing

- Added vCurrentSensing_IsReady() API
- Enables validation of ADC sample before it is used by control layer

This step introduces a deterministic and configurable synchronization point between:

ADC acquisition
current sensing
control loop execution

while keeping the system scalable for advanced control strategies.

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/82