### PR TITLE
feature/ID83 svpwm sector detection

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -105,15 +105,63 @@ void vMotorControl_Process(void) {
   */
 }
 
+/**
+ * @brief Check if motor control loop is ready to execute
+ *
+ * This function evaluates whether the control loop should be executed.
+ * It implements a "consume-on-read" mechanism:
+ *
+ * - If the control loop flag is set, it clears the flag and returns true
+ * - Otherwise, it returns false
+ *
+ * This ensures the control loop runs exactly once per valid trigger event
+ * (e.g., after sufficient ADC samples have been collected).
+ *
+ * @note Typically called from ISR context after ADC sampling.
+ *
+ * @return true  Control loop is ready and should execute
+ * @return false Control loop is not ready
+ */
 bool vMotorControl_IsControlReady(void) {
+  bool bReady = false;
   if (MotorControl_State.ui8RunControlLoop) {
     MotorControl_State.ui8RunControlLoop = 0;
-    return true;
+    bReady = true;
+  } else {
+    /*do nothing*/
   }
-
-  return false;
+  return bReady;
 }
 
+/**
+ * @brief Execute motor control pipeline (FOC + SVPWM)
+ *
+ * This function runs the complete motor control algorithm when triggered.
+ * It is typically executed inside the ADC interrupt context once enough
+ * samples have been collected (sample gating).
+ *
+ * Control pipeline:
+ *
+ *  5. Reconstruct phase currents from DC-link current (single-shunt)
+ *  6. Clarke transform (abc → αβ)
+ *  7. Park transform (αβ → dq)
+ *  8. Current control (PI regulators in dq frame)
+ *  9. Inverse Park transform (dq → αβ)
+ *  4. SVPWM sector detection (handled internally by SVM module)
+ * 10. SVPWM computation (duty cycle generation)
+ * 11. PWM update (CCR registers)
+ * 12. Prepare next cycle (state reset, synchronization)
+ *
+ * @note
+ * - SVPWM sector detection is not explicitly performed here; it is handled
+ *   internally by the SVM module during duty cycle computation.
+ * - This function is designed to run in ISR context, so execution time
+ *   must be bounded and deterministic.
+ *
+ * @warning
+ * Ensure that total execution time is less than PWM period to avoid
+ * control instability.
+ */
 void vMotorControl_RunControl(void) {
   /* 5. Reconstruct phase currents from DC-link current */
 

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -121,3 +121,24 @@ void vMotorControl_SetSampleReady(bool bReady) {
     MotorControl_State.ui8RunControlLoop = 1;
   }
 }
+
+void vMotorControl_RunControl(void) {
+  /* 4. Detect active SVPWM sector (1..6) */
+
+  /* 5. Reconstruct phase currents from DC-link current */
+
+  /* 6. Clarke transform (abc -> alpha-beta) */
+
+  /* 7. Park transform (alpha-beta -> dq) */
+
+  /* 8. Current control (PI controllers) */
+
+  /* 9. Inverse Park transform (dq -> alpha-beta) */
+
+  /* 10. SVPWM computation */
+  /* Convert alpha-beta voltages to duty cycles */
+
+  /* 11. Update PWM registers (CCR1, CCR2, CCR3) */
+
+  /* 12. Prepare next cycle */
+}

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -104,3 +104,20 @@ void vMotorControl_Process(void) {
   }
   */
 }
+
+bool vMotorControl_IsControlReady(void) {
+  if (MotorControl_State.ui8RunControlLoop) {
+    MotorControl_State.ui8RunControlLoop = 0;
+    return true;
+  }
+
+  return false;
+}
+
+void vMotorControl_SetSampleReady(bool bReady) {
+  MotorControl_State.ui8SampleReady = (uint8_t)bReady;
+
+  if (bReady) {
+    MotorControl_State.ui8RunControlLoop = 1;
+  }
+}

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -123,8 +123,6 @@ void vMotorControl_SetSampleReady(bool bReady) {
 }
 
 void vMotorControl_RunControl(void) {
-  /* 4. Detect active SVPWM sector (1..6) */
-
   /* 5. Reconstruct phase currents from DC-link current */
 
   /* 6. Clarke transform (abc -> alpha-beta) */
@@ -135,6 +133,9 @@ void vMotorControl_RunControl(void) {
 
   /* 9. Inverse Park transform (dq -> alpha-beta) */
 
+  /* 4. Detect active SVPWM sector (1..6) */
+  /* NOTE: Sector detection is handled internally by SVM */
+  
   /* 10. SVPWM computation */
   /* Convert alpha-beta voltages to duty cycles */
 

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -114,14 +114,6 @@ bool vMotorControl_IsControlReady(void) {
   return false;
 }
 
-void vMotorControl_SetSampleReady(bool bReady) {
-  MotorControl_State.ui8SampleReady = (uint8_t)bReady;
-
-  if (bReady) {
-    MotorControl_State.ui8RunControlLoop = 1;
-  }
-}
-
 void vMotorControl_RunControl(void) {
   /* 5. Reconstruct phase currents from DC-link current */
 
@@ -135,7 +127,7 @@ void vMotorControl_RunControl(void) {
 
   /* 4. Detect active SVPWM sector (1..6) */
   /* NOTE: Sector detection is handled internally by SVM */
-  
+
   /* 10. SVPWM computation */
   /* Convert alpha-beta voltages to duty cycles */
 

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.h
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.h
@@ -131,6 +131,7 @@ void vMotorControl_Process(void);
  */
 void vMotorControl_SetSampleReady(bool bReady);
 
+bool vMotorControl_IsControlReady(void);
 #ifdef __cplusplus
 }
 #endif

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.h
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.h
@@ -130,7 +130,47 @@ void vMotorControl_Process(void);
  * @param bReady true if sample is ready, false otherwise
  */
 void vMotorControl_SetSampleReady(bool bReady);
+
+/**
+ * @brief Execute motor control pipeline (FOC + SVPWM)
+ *
+ * Runs the full motor control algorithm when triggered by the sampling
+ * and synchronization logic.
+ *
+ * Control pipeline:
+ *  - Phase current reconstruction (DC-link → phase currents)
+ *  - Clarke transform (abc → αβ)
+ *  - Park transform (αβ → dq)
+ *  - Current control (PI in dq frame)
+ *  - Inverse Park transform (dq → αβ)
+ *  - SVPWM computation (includes sector detection internally)
+ *  - PWM duty cycle update
+ *
+ * This function is typically executed in ISR context after ADC sampling
+ * and gating conditions are met.
+ *
+ * @note SVPWM sector detection is handled internally by the SVM module.
+ *
+ * @warning Execution time must be shorter than PWM period.
+ */
 void vMotorControl_RunControl(void);
+
+/**
+ * @brief Check if control loop execution is ready
+ *
+ * Determines whether the motor control loop should be executed.
+ * Implements a consume-on-read mechanism:
+ *
+ * - Returns true if control loop is ready and clears the internal flag
+ * - Returns false if no execution is pending
+ *
+ * This guarantees that the control loop runs exactly once per trigger event.
+ *
+ * Typically used in ISR after ADC sample processing.
+ *
+ * @return true  Control loop should execute
+ * @return false Control loop not ready
+ */
 bool vMotorControl_IsControlReady(void);
 #ifdef __cplusplus
 }

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.h
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.h
@@ -130,7 +130,7 @@ void vMotorControl_Process(void);
  * @param bReady true if sample is ready, false otherwise
  */
 void vMotorControl_SetSampleReady(bool bReady);
-
+void vMotorControl_RunControl(void);
 bool vMotorControl_IsControlReady(void);
 #ifdef __cplusplus
 }

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -190,7 +190,7 @@ void vKernelInterface_ADCIRQHandler(void) {
     if (vMotorControl_IsControlReady()) {
       vMotorControl_RunControl();
     }
+    /* Clear EOC flag (if not handled in driver) */
+    vADC_ClearEOCflag();
   }
-  /* Clear EOC flag (if not handled in driver) */
-  vADC_ClearEOCflag();
 }

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -175,7 +175,7 @@ void vKernelInterface_USART1IRQHandler(void) {
 }
 
 void vKernelInterface_ADCIRQHandler(void) {
-  if (ADC1->ISR & ADC_ISR_EOC) {
+  if (vADC_GetEOCInterruptFlag()) {
 
     /* 1. Acquire DC-link current sample (Ibus) */
     int16_t i16VoltageBus = vADC_i16ReadRaw();
@@ -191,4 +191,6 @@ void vKernelInterface_ADCIRQHandler(void) {
       vMotorControl_RunControl();
     }
   }
+  /* Clear EOC flag (if not handled in driver) */
+  vADC_ClearEOCflag();
 }

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -189,6 +189,8 @@ void vKernelInterface_ADCIRQHandler(void) {
     /* Check if control loop should run (based on sample gating) */
     if (vMotorControl_IsControlReady()) {
       vMotorControl_RunControl();
+    } else {
+      /* do nothing*/
     }
     /* Clear EOC flag (if not handled in driver) */
     vADC_ClearEOCflag();

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -188,24 +188,7 @@ void vKernelInterface_ADCIRQHandler(void) {
 
     /* Check if control loop should run (based on sample gating) */
     if (vMotorControl_IsControlReady()) {
-      /* 4. Detect active SVPWM sector (1..6) */
-
-      /* 5. Reconstruct phase currents from DC-link current */
-
-      /* 6. Clarke transform (abc -> alpha-beta) */
-
-      /* 7. Park transform (alpha-beta -> dq) */
-
-      /* 8. Current control (PI controllers) */
-
-      /* 9. Inverse Park transform (dq -> alpha-beta) */
-
-      /* 10. SVPWM computation */
-      /* Convert alpha-beta voltages to duty cycles */
-
-      /* 11. Update PWM registers (CCR1, CCR2, CCR3) */
-
-      /* 12. Prepare next cycle */
+      vMotorControl_RunControl();
     }
   }
 }

--- a/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
+++ b/STM32CubeIDE/src/Board/BoardApp/InterruptTask.c
@@ -186,23 +186,26 @@ void vKernelInterface_ADCIRQHandler(void) {
     /* 3. Check if enough samples are available (typically 2 per PWM cycle) */
     /*this step is inside vMotorControl_OnAdcSample function*/
 
-    /* 4. Detect active SVPWM sector (1..6) */
+    /* Check if control loop should run (based on sample gating) */
+    if (vMotorControl_IsControlReady()) {
+      /* 4. Detect active SVPWM sector (1..6) */
 
-    /* 5. Reconstruct phase currents from DC-link current */
+      /* 5. Reconstruct phase currents from DC-link current */
 
-    /* 6. Clarke transform (abc -> alpha-beta) */
+      /* 6. Clarke transform (abc -> alpha-beta) */
 
-    /* 7. Park transform (alpha-beta -> dq) */
+      /* 7. Park transform (alpha-beta -> dq) */
 
-    /* 8. Current control (PI controllers) */
+      /* 8. Current control (PI controllers) */
 
-    /* 9. Inverse Park transform (dq -> alpha-beta) */
+      /* 9. Inverse Park transform (dq -> alpha-beta) */
 
-    /* 10. SVPWM computation */
-    /* Convert alpha-beta voltages to duty cycles */
+      /* 10. SVPWM computation */
+      /* Convert alpha-beta voltages to duty cycles */
 
-    /* 11. Update PWM registers (CCR1, CCR2, CCR3) */
+      /* 11. Update PWM registers (CCR1, CCR2, CCR3) */
 
-    /* 12. Prepare next cycle */
+      /* 12. Prepare next cycle */
+    }
   }
 }

--- a/STM32CubeIDE/src/Board/HAL/adc.c
+++ b/STM32CubeIDE/src/Board/HAL/adc.c
@@ -214,3 +214,7 @@ void cbADC(void) {
   adc.ui8initialized = 0;
   vADC_Init(&adc);
 }
+
+bool vADC_GetEOCInterruptFlag(void) { return (bool)(ADC1->ISR & ADC_ISR_EOC); }
+
+void vADC_ClearEOCflag(void) { ADC1->ISR |= ADC_ISR_EOC; }

--- a/STM32CubeIDE/src/Board/HAL/adc.h
+++ b/STM32CubeIDE/src/Board/HAL/adc.h
@@ -45,8 +45,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #include "stm32g031xx.h"
+#include <stdbool.h>
 
 /**
  * @brief ADC object structure.
@@ -104,6 +104,8 @@ void vADC_Disable(void);
 
 int16_t vADC_i16ReadRaw(void);
 
+bool vADC_GetEOCInterruptFlag(void);
+void vADC_ClearEOCflag(void);
 #ifdef __cplusplus
 }
 #endif

--- a/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
+++ b/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
@@ -54,6 +54,26 @@ void vCurrentSensing_UpdateRaw(int16_t i16AdcRaw) {
   CurrentSensing_State.ui8Valid = 1;
 }
 
+/**
+ * @brief Check if a valid current sample is available
+ *
+ * This function indicates whether the current sensing module has a valid
+ * and usable measurement available. The validity flag is set when a new
+ * ADC sample has been processed and converted into a current value.
+ *
+ * @details
+ * - Returns the internal validity flag without modifying it
+ * - Does not consume or clear the flag (non-destructive read)
+ * - Intended to be used by upper layers (e.g., MotorControl) to verify
+ *   data readiness before executing control algorithms
+ *
+ * @note
+ * This function is typically called after vCurrentSensing_UpdateRaw()
+ * within the control pipeline.
+ *
+ * @return true  A valid current sample is available
+ * @return false No valid sample available
+ */
 bool vCurrentSensing_IsReady(void) {
   return (CurrentSensing_State.ui8Valid != 0);
 }


### PR DESCRIPTION
This PR completes step 4 of the control pipeline, integrating SVPWM sector detection into the system architecture.

Instead of implementing sector detection as a standalone function in the control layer, the design leverages the existing SVM module, where sector computation is inherently required for duty cycle generation.

MotorControl
Defined execution pipeline in vMotorControl_RunControl()
Clarified control stages (steps 5–12) through structured comments
Removed standalone sector detection from MotorControl
Delegated SVPWM responsibilities to SVM module
SVM
Reused existing u8SVM_GetSector() for sector determination
Confirmed sector detection is performed internally during duty computation
Maintained compatibility with current standalone (open-loop) SVM mode

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/83