### PR TITLE
feature/ID84 current reconstruction

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -163,8 +163,8 @@ bool vMotorControl_IsControlReady(void) {
  * control instability.
  */
 void vMotorControl_RunControl(void) {
-   float ia, ib, ic;
-   
+  float ia, ib, ic;
+
   /* 5. Reconstruct phase currents from DC-link current */
   vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
 

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -163,7 +163,10 @@ bool vMotorControl_IsControlReady(void) {
  * control instability.
  */
 void vMotorControl_RunControl(void) {
+   float ia, ib, ic;
+   
   /* 5. Reconstruct phase currents from DC-link current */
+  vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
 
   /* 6. Clarke transform (abc -> alpha-beta) */
 

--- a/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
+++ b/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
@@ -78,11 +78,10 @@ bool vCurrentSensing_IsReady(void) {
   return (CurrentSensing_State.ui8Valid != 0);
 }
 
-void vCurrentSensing_ReconstructABC(float *ia, float *ib, float *ic)
-{
-    float ibus = CurrentSensing_State.fCurrent_A;
+void vCurrentSensing_ReconstructABC(float *ia, float *ib, float *ic) {
+  float ibus = CurrentSensing_State.fCurrent_A;
 
-    *ia = ibus;
-    *ib = -0.5f * ibus;
-    *ic = -0.5f * ibus;
+  *ia = ibus;
+  *ib = -0.5f * ibus;
+  *ic = -0.5f * ibus;
 }

--- a/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
+++ b/STM32CubeIDE/src_libs/MCLib/CurrentSensing.c
@@ -77,3 +77,12 @@ void vCurrentSensing_UpdateRaw(int16_t i16AdcRaw) {
 bool vCurrentSensing_IsReady(void) {
   return (CurrentSensing_State.ui8Valid != 0);
 }
+
+void vCurrentSensing_ReconstructABC(float *ia, float *ib, float *ic)
+{
+    float ibus = CurrentSensing_State.fCurrent_A;
+
+    *ia = ibus;
+    *ib = -0.5f * ibus;
+    *ic = -0.5f * ibus;
+}

--- a/STM32CubeIDE/src_libs/MCLib/CurrentSensing.h
+++ b/STM32CubeIDE/src_libs/MCLib/CurrentSensing.h
@@ -113,4 +113,6 @@ void vCurrentSensing_SetOffset(int16_t offset);
  */
 bool vCurrentSensing_IsReady(void);
 
+void vCurrentSensing_ReconstructABC(float *ia, float *ib, float *ic);
+
 #endif /* CURRENT_SENSING_H_ */


### PR DESCRIPTION
This PR implements step 5 of the motor control pipeline, introducing a temporary phase current reconstruction from DC-link current measurements.

The implementation enables the FOC pipeline to execute end-to-end while deferring the full single-shunt reconstruction algorithm to a later stage.

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/84