### PR TITLE
feature/ID85 Clarke transformation

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -164,11 +164,13 @@ bool vMotorControl_IsControlReady(void) {
  */
 void vMotorControl_RunControl(void) {
   float ia, ib, ic;
+  float ialpha, ibeta;
 
   /* 5. Reconstruct phase currents from DC-link current */
   vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
 
   /* 6. Clarke transform (abc -> alpha-beta) */
+  vFOC_Clarke(ia, ib, ic, &ialpha, &ibeta);
 
   /* 7. Park transform (alpha-beta -> dq) */
 

--- a/STM32CubeIDE/src_libs/MCLib/FOC.c
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.c
@@ -10,3 +10,16 @@
  * @license
  * This source code is provided for educational and research purposes.
  */
+#include <math.h>
+
+#define ONE_BY_SQRT3 (0.57735026919f)
+
+/**
+ * @brief Clarke transform implementation
+ */
+void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta) {
+  (void)ic; // no se usa en forma reducida
+
+  *ialpha = ia;
+  *ibeta = (ia + 2.0f * ib) * ONE_BY_SQRT3;
+}

--- a/STM32CubeIDE/src_libs/MCLib/FOC.h
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.h
@@ -123,4 +123,26 @@ bool vFOC_IsReady(void);
  */
 tFOC_State *vFOC_GetState(void);
 
+/**
+ * @brief Perform Clarke transformation (abc → αβ)
+ *
+ * Converts three-phase currents (ia, ib, ic) into the stationary
+ * two-axis reference frame (alpha-beta).
+ *
+ * Uses the reduced Clarke transform assuming a balanced system:
+ * ia + ib + ic = 0
+ *
+ * Equations:
+ *  - i_alpha = ia
+ *  - i_beta  = (ia + 2 * ib) / sqrt(3)
+ *
+ * @param[in]  ia     Phase A current
+ * @param[in]  ib     Phase B current
+ * @param[in]  ic     Phase C current (unused in reduced form)
+ * @param[out] ialpha Alpha-axis component
+ * @param[out] ibeta  Beta-axis component
+ *
+ * @note Common in FOC implementations
+ */
+void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta);
 #endif /* __FOC_H */


### PR DESCRIPTION
This PR implements step 6 of the motor control pipeline, introducing the Clarke transformation to convert reconstructed phase currents (abc) into the stationary αβ reference frame.

This is the first mathematically complete stage of the FOC algorithm and enables progression toward dq-domain control.

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/85