### PR TITLE
feature/ID86 Park transform

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -20,8 +20,8 @@
 
 #include "MotorControl.h"
 #include "CurrentSensing.h"
-#include <stdint.h>
 #include "svm.h"
+#include <stdint.h>
 
 extern SVM_t svm;
 /**

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -21,7 +21,9 @@
 #include "MotorControl.h"
 #include "CurrentSensing.h"
 #include <stdint.h>
+#include "svm.h"
 
+extern SVM_t svm;
 /**
  * @brief Internal motor control state
  *
@@ -165,6 +167,8 @@ bool vMotorControl_IsControlReady(void) {
 void vMotorControl_RunControl(void) {
   float ia, ib, ic;
   float ialpha, ibeta;
+  float sinTheta, cosTheta;
+  float id, iq;
 
   /* 5. Reconstruct phase currents from DC-link current */
   vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
@@ -172,7 +176,11 @@ void vMotorControl_RunControl(void) {
   /* 6. Clarke transform (abc -> alpha-beta) */
   vFOC_Clarke(ia, ib, ic, &ialpha, &ibeta);
 
+  sinTheta = sinf(svm.theta);
+  cosTheta = cosf(svm.theta);
+
   /* 7. Park transform (alpha-beta -> dq) */
+  vFOC_Park(ialpha, ibeta, sinTheta, cosTheta, &id, &iq);
 
   /* 8. Current control (PI controllers) */
 

--- a/STM32CubeIDE/src_libs/MCLib/FOC.c
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.c
@@ -23,3 +23,14 @@ void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta) {
   *ialpha = ia;
   *ibeta = (ia + 2.0f * ib) * ONE_BY_SQRT3;
 }
+
+/**
+ * @brief Park transform implementation
+ *
+ * Converts alpha-beta currents into dq frame using provided angle.
+ */
+void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
+               float *id, float *iq) {
+  *id = ialpha * cosTheta + ibeta * sinTheta;
+  *iq = -ialpha * sinTheta + ibeta * cosTheta;
+}

--- a/STM32CubeIDE/src_libs/MCLib/FOC.h
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.h
@@ -145,4 +145,34 @@ tFOC_State *vFOC_GetState(void);
  * @note Common in FOC implementations
  */
 void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta);
+
+/**
+ * @brief Perform Park transformation (αβ → dq)
+ *
+ * Converts stationary reference frame currents (alpha-beta) into the
+ * rotating reference frame (d-q) using the electrical angle.
+ *
+ * This transformation aligns the d-axis with the rotor flux, enabling
+ * decoupled control of flux (Id) and torque (Iq).
+ *
+ * Transformation equations:
+ *  - id =  ialpha * cos(theta) + ibeta * sin(theta)
+ *  - iq = -ialpha * sin(theta) + ibeta * cos(theta)
+ *
+ * @param[in]  ialpha    Alpha-axis current component
+ * @param[in]  ibeta     Beta-axis current component
+ * @param[in]  sinTheta  Sine of electrical angle (θ)
+ * @param[in]  cosTheta  Cosine of electrical angle (θ)
+ * @param[out] id        Direct-axis current component (flux)
+ * @param[out] iq        Quadrature-axis current component (torque)
+ *
+ * @note
+ * - Requires precomputed sin(θ) and cos(θ) for efficiency
+ * - Typically used after Clarke transform in FOC pipeline
+ *
+ * @warning
+ * Accuracy depends on the correctness of the electrical angle (θ)
+ */
+void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
+               float *id, float *iq);
 #endif /* __FOC_H */


### PR DESCRIPTION
Implements Park transformation to convert stationary alpha-beta currents into rotating dq frame using electrical angle (sinθ, cosθ).

Enables decoupled control of flux (Id) and torque (Iq) and prepares the pipeline for PI current control stage.

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/86