### PR TITLE
feature/ID87 current control

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -20,7 +20,9 @@
 
 #include "MotorControl.h"
 #include "CurrentSensing.h"
+#include "FOC.h"
 #include "svm.h"
+#include <math.h>
 #include <stdint.h>
 
 extern SVM_t svm;
@@ -169,6 +171,7 @@ void vMotorControl_RunControl(void) {
   float ialpha, ibeta;
   float sinTheta, cosTheta;
   float id, iq;
+  float vd, vq;
 
   /* 5. Reconstruct phase currents from DC-link current */
   vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
@@ -183,6 +186,11 @@ void vMotorControl_RunControl(void) {
   vFOC_Park(ialpha, ibeta, sinTheta, cosTheta, &id, &iq);
 
   /* 8. Current control (PI controllers) */
+  float id_ref = 0.0f;
+  float iq_ref = 0.5f; /* torque command dummy*/
+
+  /* 8. Current control (PI controllers) */
+  vFOC_CurrentControl(id, iq, id_ref, iq_ref, &vd, &vq);
 
   /* 9. Inverse Park transform (dq -> alpha-beta) */
 

--- a/STM32CubeIDE/src_libs/MCLib/FOC.c
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.c
@@ -41,6 +41,9 @@ void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
   *iq = -ialpha * sinTheta + ibeta * cosTheta;
 }
 
+/**
+ * @brief Current control implementation using PI regulators
+ */
 void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
                          float *vd, float *vq) {
   float err_d = id_ref - id;
@@ -50,29 +53,47 @@ void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
   *vq = fPI_Run(&pi_q, err_q);
 }
 
+/**
+ * @brief PI controller execution with basic anti-windup
+ *
+ * Implements a proportional-integral controller with output saturation
+ * and simple anti-windup correction.
+ *
+ * @param[in,out] pi     Pointer to PI controller structure
+ * @param[in]     error  Control error input
+ * @return Control output (saturated)
+ */
 static float fPI_Run(PI_Controller_t *pi, float error) {
-  /* Proporcional */
+  /* Proportional term */
   float p = pi->kp * error;
 
-  /* Integrador */
+  /* Integral term */
   pi->integrator += pi->ki * error;
 
-  /* Suma */
+  /* Raw output */
   float out = p + pi->integrator;
 
-  /* Saturación + anti-windup simple */
+  /* Saturation + anti-windup */
   if (out > pi->out_max) {
     out = pi->out_max;
-    /* evitar seguir integrando hacia arriba */
+
+    /* Prevent further integration in positive direction */
     if (error > 0.0f) {
       pi->integrator -= pi->ki * error;
+    } else {
+      /*do nothing*/
     }
   } else if (out < pi->out_min) {
     out = pi->out_min;
-    /* evitar seguir integrando hacia abajo */
+
+    /* Prevent further integration in negative direction */
     if (error < 0.0f) {
       pi->integrator -= pi->ki * error;
+    } else {
+      /* do nothing*/
     }
+  } else {
+    /*do nothing*/
   }
 
   return out;

--- a/STM32CubeIDE/src_libs/MCLib/FOC.c
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.c
@@ -10,9 +10,15 @@
  * @license
  * This source code is provided for educational and research purposes.
  */
+#include "FOC.h"
 #include <math.h>
 
-#define ONE_BY_SQRT3 (0.57735026919f)
+#define dONE_BY_SQRT3 (0.57735026919f)
+
+static PI_Controller_t pi_d;
+static PI_Controller_t pi_q;
+
+static float fPI_Run(PI_Controller_t *pi, float error);
 
 /**
  * @brief Clarke transform implementation
@@ -21,7 +27,7 @@ void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta) {
   (void)ic; // no se usa en forma reducida
 
   *ialpha = ia;
-  *ibeta = (ia + 2.0f * ib) * ONE_BY_SQRT3;
+  *ibeta = (ia + 2.0f * ib) * dONE_BY_SQRT3;
 }
 
 /**
@@ -33,4 +39,41 @@ void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
                float *id, float *iq) {
   *id = ialpha * cosTheta + ibeta * sinTheta;
   *iq = -ialpha * sinTheta + ibeta * cosTheta;
+}
+
+void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
+                         float *vd, float *vq) {
+  float err_d = id_ref - id;
+  float err_q = iq_ref - iq;
+
+  *vd = fPI_Run(&pi_d, err_d);
+  *vq = fPI_Run(&pi_q, err_q);
+}
+
+static float fPI_Run(PI_Controller_t *pi, float error) {
+  /* Proporcional */
+  float p = pi->kp * error;
+
+  /* Integrador */
+  pi->integrator += pi->ki * error;
+
+  /* Suma */
+  float out = p + pi->integrator;
+
+  /* Saturación + anti-windup simple */
+  if (out > pi->out_max) {
+    out = pi->out_max;
+    /* evitar seguir integrando hacia arriba */
+    if (error > 0.0f) {
+      pi->integrator -= pi->ki * error;
+    }
+  } else if (out < pi->out_min) {
+    out = pi->out_min;
+    /* evitar seguir integrando hacia abajo */
+    if (error < 0.0f) {
+      pi->integrator -= pi->ki * error;
+    }
+  }
+
+  return out;
 }

--- a/STM32CubeIDE/src_libs/MCLib/FOC.h
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.h
@@ -202,6 +202,23 @@ void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta);
 void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
                float *id, float *iq);
 
+/**
+ * @brief Executes current control loop (PI controllers)
+ *
+ * Computes the voltage references (vd, vq) based on the error
+ * between reference currents and measured currents in dq frame.
+ *
+ * This function implements two independent PI controllers:
+ * - d-axis (flux control)
+ * - q-axis (torque control)
+ *
+ * @param[in]  id      Measured d-axis current
+ * @param[in]  iq      Measured q-axis current
+ * @param[in]  id_ref  Reference d-axis current
+ * @param[in]  iq_ref  Reference q-axis current
+ * @param[out] vd      Output d-axis voltage reference
+ * @param[out] vq      Output q-axis voltage reference
+ */
 void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
                          float *vd, float *vq);
 #endif /* __FOC_H */

--- a/STM32CubeIDE/src_libs/MCLib/FOC.h
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -59,6 +60,31 @@ typedef struct {
   } adc;
 
 } tFOC_State;
+
+/**
+ * @brief PI controller structure
+ *
+ * Holds parameters and state for a proportional-integral controller
+ * with output saturation.
+ */
+typedef struct {
+
+  /** @brief Proportional gain */
+  float kp;
+
+  /** @brief Integral gain */
+  float ki;
+
+  /** @brief Integrator accumulator */
+  float integrator;
+
+  /** @brief Minimum output limit */
+  float out_min;
+
+  /** @brief Maximum output limit */
+  float out_max;
+
+} PI_Controller_t;
 
 /**
  * @brief Initialize FOC module
@@ -175,4 +201,7 @@ void vFOC_Clarke(float ia, float ib, float ic, float *ialpha, float *ibeta);
  */
 void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
                float *id, float *iq);
+
+void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
+                         float *vd, float *vq);
 #endif /* __FOC_H */


### PR DESCRIPTION
This PR implements step 8 of the motor control pipeline, introducing the current control stage in the dq reference frame using two independent PI controllers.

This stage computes the voltage references (vd, vq) based on the error between reference currents and measured currents, enabling closed-loop torque and flux control.

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/87