### PR TITLE
feature/ID88 inverse park

### DIFF
--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -172,6 +172,8 @@ void vMotorControl_RunControl(void) {
   float sinTheta, cosTheta;
   float id, iq;
   float vd, vq;
+  float valpha, vbeta;
+
 
   /* 5. Reconstruct phase currents from DC-link current */
   vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
@@ -193,10 +195,11 @@ void vMotorControl_RunControl(void) {
   vFOC_CurrentControl(id, iq, id_ref, iq_ref, &vd, &vq);
 
   /* 9. Inverse Park transform (dq -> alpha-beta) */
+  vFOC_InversePark(vd, vq, sinTheta, cosTheta, &valpha, &vbeta);
 
   /* 4. Detect active SVPWM sector (1..6) */
   /* NOTE: Sector detection is handled internally by SVM */
-
+   
   /* 10. SVPWM computation */
   /* Convert alpha-beta voltages to duty cycles */
 

--- a/STM32CubeIDE/src/APP/Inverter/MotorControl.c
+++ b/STM32CubeIDE/src/APP/Inverter/MotorControl.c
@@ -174,7 +174,6 @@ void vMotorControl_RunControl(void) {
   float vd, vq;
   float valpha, vbeta;
 
-
   /* 5. Reconstruct phase currents from DC-link current */
   vCurrentSensing_ReconstructABC(&ia, &ib, &ic);
 
@@ -199,7 +198,7 @@ void vMotorControl_RunControl(void) {
 
   /* 4. Detect active SVPWM sector (1..6) */
   /* NOTE: Sector detection is handled internally by SVM */
-   
+
   /* 10. SVPWM computation */
   /* Convert alpha-beta voltages to duty cycles */
 

--- a/STM32CubeIDE/src_libs/MCLib/FOC.c
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.c
@@ -115,10 +115,8 @@ static float fPI_Run(PI_Controller_t *pi, float error) {
  * @param[out] valpha    Alpha-axis voltage output
  * @param[out] vbeta     Beta-axis voltage output
  */
-void vFOC_InversePark(float vd, float vq,
-                      float sinTheta, float cosTheta,
-                      float *valpha, float *vbeta)
-{
-    *valpha = vd * cosTheta - vq * sinTheta;
-    *vbeta  = vd * sinTheta + vq * cosTheta;
+void vFOC_InversePark(float vd, float vq, float sinTheta, float cosTheta,
+                      float *valpha, float *vbeta) {
+  *valpha = vd * cosTheta - vq * sinTheta;
+  *vbeta = vd * sinTheta + vq * cosTheta;
 }

--- a/STM32CubeIDE/src_libs/MCLib/FOC.c
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.c
@@ -98,3 +98,27 @@ static float fPI_Run(PI_Controller_t *pi, float error) {
 
   return out;
 }
+
+/**
+ * @brief Inverse Park transformation (dq → αβ)
+ *
+ * Converts voltage references from the rotating dq reference frame
+ * into the stationary alpha-beta frame using the electrical angle.
+ *
+ * This function is used in the FOC control loop to generate the
+ * stationary voltage vector required by the SVPWM stage.
+ *
+ * @param[in]  vd        d-axis voltage reference
+ * @param[in]  vq        q-axis voltage reference
+ * @param[in]  sinTheta  Sine of electrical angle θ
+ * @param[in]  cosTheta  Cosine of electrical angle θ
+ * @param[out] valpha    Alpha-axis voltage output
+ * @param[out] vbeta     Beta-axis voltage output
+ */
+void vFOC_InversePark(float vd, float vq,
+                      float sinTheta, float cosTheta,
+                      float *valpha, float *vbeta)
+{
+    *valpha = vd * cosTheta - vq * sinTheta;
+    *vbeta  = vd * sinTheta + vq * cosTheta;
+}

--- a/STM32CubeIDE/src_libs/MCLib/FOC.h
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.h
@@ -221,4 +221,21 @@ void vFOC_Park(float ialpha, float ibeta, float sinTheta, float cosTheta,
  */
 void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
                          float *vd, float *vq);
+
+/**
+ * @brief Perform Inverse Park transformation (dq → αβ)
+ *
+ * Converts rotating frame voltages (d-q) into stationary
+ * alpha-beta frame using electrical angle.
+ *
+ * @param[in]  vd        d-axis voltage reference
+ * @param[in]  vq        q-axis voltage reference
+ * @param[in]  sinTheta  sine of electrical angle
+ * @param[in]  cosTheta  cosine of electrical angle
+ * @param[out] valpha    alpha-axis voltage
+ * @param[out] vbeta     beta-axis voltage
+ */
+void vFOC_InversePark(float vd, float vq,
+                      float sinTheta, float cosTheta,
+                      float *valpha, float *vbeta);
 #endif /* __FOC_H */

--- a/STM32CubeIDE/src_libs/MCLib/FOC.h
+++ b/STM32CubeIDE/src_libs/MCLib/FOC.h
@@ -235,7 +235,6 @@ void vFOC_CurrentControl(float id, float iq, float id_ref, float iq_ref,
  * @param[out] valpha    alpha-axis voltage
  * @param[out] vbeta     beta-axis voltage
  */
-void vFOC_InversePark(float vd, float vq,
-                      float sinTheta, float cosTheta,
+void vFOC_InversePark(float vd, float vq, float sinTheta, float cosTheta,
                       float *valpha, float *vbeta);
 #endif /* __FOC_H */


### PR DESCRIPTION
This PR implements step 9 of the motor control pipeline, introducing the Inverse Park transformation to convert voltage references from the rotating dq frame into the stationary αβ frame.

This stage is required to interface the current control outputs (vd, vq) with the Space Vector Modulation (SVM) stage.

https://github.com/Jbritoloaiza22/Inverter-drive-training/issues/88